### PR TITLE
Quick enemy stat fix, so they work properly for the sprint review

### DIFF
--- a/Game/Scenes/Characters/default_enemy.tscn
+++ b/Game/Scenes/Characters/default_enemy.tscn
@@ -17,6 +17,7 @@ radius = 4826.92
 collision_layer = 16
 motion_mode = 1
 script = ExtResource("1_fecjr")
+speed = 180.0
 
 [node name="Health" type="Node2D" parent="."]
 script = ExtResource("2_ihcfn")

--- a/Game/Scenes/Characters/ranged_enemy.tscn
+++ b/Game/Scenes/Characters/ranged_enemy.tscn
@@ -7,8 +7,8 @@
 [sub_resource type="CircleShape2D" id="CircleShape2D_1deiu"]
 radius = 13.0
 
-[sub_resource type="RectangleShape2D" id="RectangleShape2D_u2wu2"]
-size = Vector2(86, 72)
+[sub_resource type="CircleShape2D" id="CircleShape2D_u2wu2"]
+radius = 180.0
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_e5mcm"]
 radius = 5206.02
@@ -16,6 +16,7 @@ radius = 5206.02
 [node name="RangedEnemy" type="CharacterBody2D" groups=["Enemies"]]
 collision_layer = 16
 script = ExtResource("1_1deiu")
+stopDistance = 180.0
 speed = 150.0
 
 [node name="Health" type="Node2D" parent="."]
@@ -32,7 +33,7 @@ shape = SubResource("CircleShape2D_1deiu")
 collision_layer = 0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="AttackRange"]
-shape = SubResource("RectangleShape2D_u2wu2")
+shape = SubResource("CircleShape2D_u2wu2")
 
 [node name="detection_area" type="Area2D" parent="."]
 collision_layer = 0


### PR DESCRIPTION
- Slowed down default_enemy speed from 200 to 180 so they can be outrun
- Changed ranged_enemy changed Stop Distance to 180 so they can move sometimes again
- Changed ranged_enemy AttackRange collision shape to circle with 180 radius to accommodate to the new Stop Distance