### PR TITLE
fix: Hide Online / Local menu

### DIFF
--- a/Game/Scenes/Menu/online_localMenu.tscn
+++ b/Game/Scenes/Menu/online_localMenu.tscn
@@ -154,6 +154,7 @@ size_flags_vertical = 3
 theme_override_constants/separation = 80
 
 [node name="Button_Online" type="Button" parent="MarginContainer2/VBoxContainer/MarginContainer/HBoxContainer2"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 80
@@ -172,6 +173,7 @@ text = "Online
 "
 
 [node name="Button_Local" type="Button" parent="MarginContainer2/VBoxContainer/MarginContainer/HBoxContainer2"]
+visible = false
 layout_mode = 2
 size_flags_horizontal = 3
 theme_override_font_sizes/font_size = 80


### PR DESCRIPTION
- This suits the expectation to have only fully implemented features by the end of Sprint 2. Buttons will be re-enabled as soon as multiplayer is refactored and fixed.

- Set visibility for Online / Local buttons to not visible