### PR TITLE
Bugfixes and maxEnemyLimit player scaling

### DIFF
--- a/Game/Scenes/Characters/default_enemy.tscn
+++ b/Game/Scenes/Characters/default_enemy.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://c8vf1rsu474lm" path="res://Scripts/Characters/BasicEnemy.cs" id="1_fecjr"]
 [ext_resource type="Script" uid="uid://dspnlxhoo12q" path="res://Scripts/Characters/Health.cs" id="2_ihcfn"]
-[ext_resource type="Texture2D" uid="uid://bcupo30ot7ngo" path="res://Assets/Characters/spritesheets/Goblin_spritesheet.png" id="3_ihcfn"]
+[ext_resource type="Texture2D" uid="uid://bgu3f86w8o3ul" path="res://Assets/Characters/spritesheets/Goblin_spritesheet.png" id="3_ihcfn"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_r4aor"]
 radius = 26.0192
@@ -159,7 +159,7 @@ animations = [{
 "speed": 7.0
 }]
 
-[node name="BasicEnemy" type="CharacterBody2D" groups=["Enemies"]]
+[node name="BasicEnemy" type="CharacterBody2D" groups=["enemies"]]
 collision_layer = 16
 collision_mask = 17
 motion_mode = 1

--- a/Game/Scenes/Characters/mounted_enemy.tscn
+++ b/Game/Scenes/Characters/mounted_enemy.tscn
@@ -76,7 +76,7 @@ animations = [{
 "speed": 5.0
 }]
 
-[node name="MountedEnemy" type="CharacterBody2D" groups=["Enemies"]]
+[node name="MountedEnemy" type="CharacterBody2D" groups=["enemies"]]
 collision_layer = 16
 script = ExtResource("1_script")
 speed = 130.0

--- a/Game/Scenes/Characters/ranged_enemy.tscn
+++ b/Game/Scenes/Characters/ranged_enemy.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://5j7tqrkdib4s" path="res://Scripts/Characters/RangedEnemy.cs" id="1_1deiu"]
 [ext_resource type="Script" uid="uid://dspnlxhoo12q" path="res://Scripts/Characters/Health.cs" id="2_u2wu2"]
-[ext_resource type="Texture2D" uid="uid://fxmo0akrmwno" path="res://Assets/Characters/spritesheets/skeleton_Spreadsheet.png" id="3_u2wu2"]
+[ext_resource type="Texture2D" uid="uid://ciqlivfxl8gv5" path="res://Assets/Characters/spritesheets/skeleton_Spreadsheet.png" id="3_u2wu2"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_u2wu2"]
 radius = 18.0
@@ -210,7 +210,7 @@ animations = [{
 "speed": 5.0
 }]
 
-[node name="RangedEnemy" type="CharacterBody2D" groups=["Enemies"]]
+[node name="RangedEnemy" type="CharacterBody2D" groups=["enemies"]]
 collision_layer = 16
 collision_mask = 17
 script = ExtResource("1_1deiu")

--- a/Game/Scenes/Characters/rider_enemy.tscn
+++ b/Game/Scenes/Characters/rider_enemy.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://m5nyfymvipg6" path="res://Scripts/Characters/Rider.cs" id="1_k7dvb"]
 [ext_resource type="Script" uid="uid://dspnlxhoo12q" path="res://Scripts/Characters/Health.cs" id="2_ilr60"]
-[ext_resource type="Texture2D" uid="uid://d1lnlbclv2a8j" path="res://Assets/Characters/Enemies/RiderWalkSheet.png" id="4_3ubfh"]
+[ext_resource type="Texture2D" uid="uid://bpwqau0js8exb" path="res://Assets/Characters/Enemies/RiderWalkSheet.png" id="4_3ubfh"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_2xkst"]
 radius = 15.0
@@ -438,11 +438,13 @@ animations = [{
 "speed": 57.0
 }]
 
-[node name="Rider" type="CharacterBody2D" groups=["Enemies"]]
+[node name="Rider" type="CharacterBody2D" groups=["enemies"]]
 collision_layer = 16
+collision_mask = 17
 script = ExtResource("1_k7dvb")
 speed = 100.0
 damage = 5.0
+animationPath = NodePath("AnimatedSprite2D")
 
 [node name="Health" type="Node2D" parent="."]
 script = ExtResource("2_ilr60")

--- a/Game/Scripts/Characters/Health.cs
+++ b/Game/Scripts/Characters/Health.cs
@@ -37,7 +37,7 @@ public partial class Health : Node2D
 			enemy.OnHit();
 
 		// death animation
-		if (health <= 0)
+		if (health <= 0) {
 			// check if parent is DefaultPlayer
 			if (GetParent() is DefaultPlayer player)
 				player.Die(); // call Die() method if parent is DefaultPlayer
@@ -47,5 +47,6 @@ public partial class Health : Node2D
 				GetParent().QueueFree(); // otherwise, free the parent node
 
 			EmitSignal(SignalName.HealthDepleted); // emit signal when health is depleted
+			}
 	}
 }

--- a/Game/Scripts/Characters/MountedEnemy.cs
+++ b/Game/Scripts/Characters/MountedEnemy.cs
@@ -22,10 +22,9 @@ public partial class MountedEnemy : EnemyBase
 		}
 	}
 
-	public override void _PhysicsProcess(double delta)
+	protected override void HandleMovement(Vector2 direction)
 	{
 		float dist = GlobalPosition.DistanceTo(player.GlobalPosition);
-
 		if (dist > stopDistance)
 		{
 			Vector2 toPlayer = (player.GlobalPosition - GlobalPosition).Normalized();

--- a/Game/Scripts/Enemies/SpawnEnemies.cs
+++ b/Game/Scripts/Enemies/SpawnEnemies.cs
@@ -63,7 +63,7 @@ public partial class SpawnEnemies : Node2D
 		PathFollow2D spawnPath = GetNode<PathFollow2D>("Path2D/PathFollow2D"); // gets a random starting position, where the enemies are spawned
 		spawnPath.ProgressRatio = GD.Randf();
 
-		EnemyPattern pattern = getPatternFromPool();
+		EnemyPattern pattern = GetPatternFromPool();
 
 		pattern.AddToGroup("EnemyPattern"); // adds the pattern to EnemyPattern group, so it can be cleaned up later on
 
@@ -118,7 +118,7 @@ public partial class SpawnEnemies : Node2D
 		//Debug.Print("Grace time has ended");
 	}
 
-	private EnemyPattern getPatternFromPool() {
+	private EnemyPattern GetPatternFromPool() {
 
 		float spawnValue = GD.Randf() * currentWave; // generate a random spawnValue to determine the difficulty of the selected enemies
 
@@ -138,7 +138,7 @@ public partial class SpawnEnemies : Node2D
 
 
 	// has to be tested if enemypattern nodes exist, can be removed if they never get added to the gameroot
-	private void deleteEmptyPatterns() // cleans up EnemyPattern nodes, which don't have any children so the NodeTree doesn't get cluttered with them
+	private void DeleteEmptyPatterns() // cleans up EnemyPattern nodes, which don't have any children so the NodeTree doesn't get cluttered with them
 	{
 		if (GetTree().GetNodesInGroup("EnemyPattern") != null)
 		{

--- a/Game/project.godot
+++ b/Game/project.godot
@@ -36,7 +36,7 @@ project/assembly_name="Game"
 [global_group]
 
 PlayerSpawnPoints=""
-Enemies=""
+enemies=""
 
 [input]
 


### PR DESCRIPTION
Fixed some minor bugs so the console doesn't get spammed with errors
Added missing maxEnemyLimit scaling with playerCount in SpawnEnemies (each player after the first increases maxEnemyLimit by 5)

Fixes and refactors:
- Refactored pattern selection logic to method getPatternFromPool() for better readability of SpawnEnemy()
- Fixed graceTime being twice as long as intended
- Changed global group "Enemies" to "enemies" for consistent weapon behaiviour
- Enabled rider collision
- Added animationPath to rider_enemy.tscn to fix error spam
- Added missing brackets to Health.doAnimation() so EmitSignal only gets sent when dying and not when hit to fix rider_enemy from spawning every time mounted_enemy is hit
- Changed _PhysicsProcess in MountedEnemies to HandleMovement to further reduce error messages