### PR TITLE
FireStaff update bugfixes

### DIFF
--- a/Game/Scenes/Characters/default_enemy.tscn
+++ b/Game/Scenes/Characters/default_enemy.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://c8vf1rsu474lm" path="res://Scripts/Characters/BasicEnemy.cs" id="1_fecjr"]
 [ext_resource type="Script" uid="uid://dspnlxhoo12q" path="res://Scripts/Characters/Health.cs" id="2_ihcfn"]
-[ext_resource type="Texture2D" uid="uid://8vahawjptqrq" path="res://Assets/Characters/spritesheets/Goblin_spritesheet.png" id="3_ihcfn"]
+[ext_resource type="Texture2D" uid="uid://bgu3f86w8o3ul" path="res://Assets/Characters/spritesheets/Goblin_spritesheet.png" id="3_ihcfn"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_r4aor"]
 radius = 26.0192
@@ -168,6 +168,7 @@ animationPath = NodePath("GoblinAnimation")
 
 [node name="Health" type="Node2D" parent="."]
 script = ExtResource("2_ihcfn")
+max_health = 100.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_r4aor")

--- a/Game/Scenes/Characters/mounted_enemy.tscn
+++ b/Game/Scenes/Characters/mounted_enemy.tscn
@@ -85,6 +85,7 @@ animationPath = NodePath("AnimatedSprite2D")
 
 [node name="Health" type="Node2D" parent="."]
 script = ExtResource("3_health")
+max_health = 100.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_body")

--- a/Game/Scenes/Characters/ranged_enemy.tscn
+++ b/Game/Scenes/Characters/ranged_enemy.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://5j7tqrkdib4s" path="res://Scripts/Characters/RangedEnemy.cs" id="1_1deiu"]
 [ext_resource type="PackedScene" uid="uid://cthg4llu6u25n" path="res://Scenes/Characters/arrow.tscn" id="2_e5mcm"]
 [ext_resource type="Script" uid="uid://dspnlxhoo12q" path="res://Scripts/Characters/Health.cs" id="2_u2wu2"]
-[ext_resource type="Texture2D" uid="uid://bhrncdbnlwv8t" path="res://Assets/Characters/spritesheets/skeleton_Spreadsheet.png" id="3_u2wu2"]
+[ext_resource type="Texture2D" uid="uid://ciqlivfxl8gv5" path="res://Assets/Characters/spritesheets/skeleton_Spreadsheet.png" id="3_u2wu2"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_u2wu2"]
 radius = 18.0
@@ -220,6 +220,7 @@ animationPath = NodePath("RangedEnemyAnimation")
 
 [node name="Health" type="Node2D" parent="."]
 script = ExtResource("2_u2wu2")
+max_health = 100.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(-2, 1)

--- a/Game/Scenes/Characters/rider_enemy.tscn
+++ b/Game/Scenes/Characters/rider_enemy.tscn
@@ -440,7 +440,6 @@ animations = [{
 
 [node name="Rider" type="CharacterBody2D" groups=["enemies"]]
 collision_layer = 16
-collision_mask = 17
 script = ExtResource("1_k7dvb")
 speed = 100.0
 damage = 5.0
@@ -448,6 +447,7 @@ animationPath = NodePath("AnimatedSprite2D")
 
 [node name="Health" type="Node2D" parent="."]
 script = ExtResource("2_ilr60")
+max_health = 100.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_2xkst")

--- a/Game/Scenes/Weapons/fireball.tscn
+++ b/Game/Scenes/Weapons/fireball.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=3 uid="uid://bg8lc8o2mf0sw"]
+[gd_scene load_steps=13 format=3 uid="uid://lv3058lpkiow"]
 
 [ext_resource type="Texture2D" uid="uid://d0iwb2p02ow1w" path="res://Assets/Weapons/MagicStaffs/Firestaff/Fireball1.png" id="1_bympj"]
 [ext_resource type="Script" uid="uid://dbgnq1xrpvxt3" path="res://Scripts/Weapons/FireBall.cs" id="1_ldwc5"]
@@ -60,24 +60,23 @@ animations = [{
 }]
 
 [node name="Fireball" type="Area2D"]
-position = Vector2(-9, 0)
 collision_layer = 4
 collision_mask = 16
 script = ExtResource("1_ldwc5")
 
 [node name="FireballAnimation" type="AnimatedSprite2D" parent="."]
-position = Vector2(2, 0)
+position = Vector2(-6.46978, 0.414137)
 rotation = -0.47822
 scale = Vector2(0.06, 0.06)
 sprite_frames = SubResource("SpriteFrames_d58m4")
 animation = &"projectile"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(9, 0)
+position = Vector2(-0.469786, 0.414137)
 shape = SubResource("CircleShape2D_hhg2a")
 
 [node name="Explosion" type="AnimatedSprite2D" parent="."]
-position = Vector2(9, -1)
+position = Vector2(-0.469786, -0.585863)
 scale = Vector2(0.5, 0.5)
 sprite_frames = SubResource("SpriteFrames_8f8e6")
 animation = &"explosion"

--- a/Game/Scripts/Characters/Health.cs
+++ b/Game/Scripts/Characters/Health.cs
@@ -4,6 +4,7 @@ using System;
 public partial class Health : Node2D
 {
 	public bool disable = false; // in multiplayer for clients, server handles health and stuff
+	[Export]
 	public float max_health;
 	public float health; // current health value
 	public float CurHealth => health; // property to access current health
@@ -22,12 +23,13 @@ public partial class Health : Node2D
 
 	public void Damage(float damage)
 	{
+		health -= damage; // reduce health by damage amount
+		
 		doAnimation(); // client has to do damage animations
 
 		if (disable) return; // Client cant do damage to enemies... server handles the damage
 
-		health -= damage; // reduce health by damage amount
-		GD.Print($"Took damage: {damage}, current health: {health}");
+		// GD.Print($"Took damage: {damage}, current health: {health}");
 	}
 
 	private void doAnimation()

--- a/Game/Scripts/Weapons/FireBall.cs
+++ b/Game/Scripts/Weapons/FireBall.cs
@@ -5,13 +5,27 @@ public partial class FireBall : Projectile
 {
 	protected float Radius = 100;
 
+	private bool hasHit = false;
+
 	public override void _Ready()
 	{
 		Speed = 600;
-		Damage = 120;
+		Damage = 60;
 	}
 	public override void OnBodyEntered(Node2D body)
 	{
+		Speed = 0;
+		SetDeferred("Monitoring", false);
+		GetNode<AnimatedSprite2D>("./FireballAnimation").Hide();
+		GetNode<AnimatedSprite2D>("./Explosion").Play("explosion");
+
+		if (!hasHit) {
+			hasHit = true;
+			DamageProcess();
+		}
+	}
+
+	private void DamageProcess() {
 		Array<Node> enemyListSnapshot = GetTree().GetNodesInGroup("enemies"); // this is to prevent some funky on enemy interactions with enemies spawned during this check
 		foreach (Node node in enemyListSnapshot) // checks if enemies are in attack radius
 		{
@@ -21,13 +35,9 @@ public partial class FireBall : Projectile
 			float dist = GlobalPosition.DistanceTo(enemyNode.GlobalPosition);
 			var healthNode = enemyNode.GetNodeOrNull<Health>("Health");
 
-			if (dist < Radius && healthNode != null) healthNode.Damage(Damage);
+			if (dist < Radius && healthNode != null)
+				healthNode.Damage(Damage);
 		}
-
-		// made with ducttape
-		GetNode<AnimatedSprite2D>("./FireballAnimation").Hide();
-		Speed = 0;
-		GetNode<AnimatedSprite2D>("./Explosion").Play("explosion");
 	}
 
 	private void OnExplosionAnimationFinished() {


### PR DESCRIPTION
- Re-added health to all enemies (for now at 100) by re-adding export to max_health
- Moved health calculation for enemies infront of the check which tells if they should be dead
- Made GD.Print in Health.Damage (which weirdly only triggered for rider) to linecomment
- Temporary fix for rider flying away: removed collision with other enemies
- Changed fireball hit logic, so it should hit enemies only once (it doesn't)

I noticed that OnBodyEntered always fires twice even in Projectile, even when setting one shot in advanced settings of the signal. I don't know how to fix this. As a temporary solution I set projectile damage of FireBall to half of intended value.