### PR TITLE
Sound Issues

### DIFF
--- a/Game/Audio/Manager/sound_manager.tscn
+++ b/Game/Audio/Manager/sound_manager.tscn
@@ -94,3 +94,4 @@ bus = &"SoundEffectBus"
 
 [node name="gameOver" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("15_uqh4n")
+bus = &"SoundEffectBus"

--- a/Game/Audio/Music/MenuBackground/menuBackgroundMusic.tscn
+++ b/Game/Audio/Music/MenuBackground/menuBackgroundMusic.tscn
@@ -5,7 +5,6 @@
 
 [node name="BackgroundAudio" type="AudioStreamPlayer"]
 stream = ExtResource("1_fww3n")
-autoplay = true
 bus = &"MenuBackgroundMusicBus"
 script = ExtResource("2_q3d37")
 


### PR DESCRIPTION
When loading into the game, previously there was an annyoing sound, which played because the backgroundmusic was set on autoplay in godot.
Additionally the gameover sound wasnt in the soundeffectbus, which it now correctly is.