### PR TITLE
fix: update join functionality to use connection codes instead of IP …

### DIFF
--- a/Game/Menu/LocalMenu.cs
+++ b/Game/Menu/LocalMenu.cs
@@ -63,8 +63,8 @@ public partial class LocalMenu : Control
 
   private void _on_join_button_pressed()
   {
-    string ipv4Pattern = @"^(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d{2}|[1-9]?\d)){3}$";
-    if (!Regex.IsMatch(ipIO.Text, ipv4Pattern)) return;
+    string codePattern = @"^\d{1,3}$";
+    if (!Regex.IsMatch(ipIO.Text, codePattern)) return;
 
     NetworkManager.Instance.InitClient(ipIO.Text);
 
@@ -105,8 +105,9 @@ public partial class LocalMenu : Control
     timer.OneShot = true;
     timer.Timeout += () => { };
     timer.Start();
-    
-    ipIO.Text = NetworkManager.Instance.GetServerIPAddress(); // show Server IP
+
+    ipIO.Text = NetworkManager.Instance.GenerateConnectionCode();
+    //NetworkManager.Instance.GetServerIPAddress(); // show Server IP
 
     //ipIO.Text = "Running";
     playButton.Visible = true;

--- a/Game/Menu/localMenu.tscn
+++ b/Game/Menu/localMenu.tscn
@@ -291,7 +291,7 @@ offset_left = 142.0
 offset_top = 546.0
 offset_right = 732.152
 offset_bottom = 545.896
-placeholder_text = "Enter IP to join"
+placeholder_text = "Enter code to join a local lobby"
 
 [node name="CurrentPlayers" type="RichTextLabel" parent="."]
 layout_mode = 0

--- a/Game/Utilities/Multiplayer/NetworkManager.cs
+++ b/Game/Utilities/Multiplayer/NetworkManager.cs
@@ -149,8 +149,9 @@ namespace Game.Utilities.Multiplayer
 			DebugIt("Server startet on port: RPC " + RPC_PORT + " + UDP " + UDP_PORT + " IP: " + GetServerIPAddress());
 		}
 
-		public void InitClient(string address)
+		public void InitClient(string code)
 		{
+			string address = ResolveConnectionCode(code);
 			// add client node as child to NetworkManager
 			client = new Client();
 			AddChild(client);
@@ -435,6 +436,22 @@ namespace Game.Utilities.Multiplayer
 				// Fallback to localhost if something goes wrong
 				return "127.0.0.1";
 			}
+		}
+
+		public string GenerateConnectionCode()
+		{
+			string ip = GetServerIPAddress();
+			var parts = ip.Split('.');
+			if (parts.Length != 4)
+				return "ERR";
+			return $"{parts[3]}";
+		}
+
+		private string ResolveConnectionCode(string code)
+		{
+			string localIp = GetServerIPAddress();
+			var prefix = string.Join(".", localIp.Split('.').Take(3));
+			return $"{prefix}.{code}";
 		}
 
 		private void DebugIt(string message)


### PR DESCRIPTION
UI zeigt jetzt einen code (letzten Teil der IP) an anstatt die komplette IP des Hosts. Der User muss also nur den letzen Teil eingeben anstatt die komplette IP. Der Ansatz funktioniert natürlich nur für local weil wir da im selben netz sind.