### PR TITLE
PR death-screen-client-418

### DIFF
--- a/Game/Utilities/Multiplayer/NetworkManager.cs
+++ b/Game/Utilities/Multiplayer/NetworkManager.cs
@@ -32,7 +32,7 @@ namespace Game.Utilities.Multiplayer
 		private Queue<Command> _incomingCommands = new();
 		private ulong _tick = 0;
 		private double _acc = 0;
-		private const float TICK_DELTA = 1f / 60f;
+		private const float TICK_DELTA = 1f / 30;
 		private Timer shutdownTimer; // for headless server if no one is connected
 		private const float ServerShutdownDelay = 5f; // seconds 
 		public static NetworkManager Instance { get; set; }
@@ -352,7 +352,7 @@ namespace Game.Utilities.Multiplayer
 				client.ApplySnapshot(snap);
 				DebugIt($"Received snapshot tick={snap.Tick}, entities={snap.Entities.Count}");
 				if (enableDebug) {
-					GD.Print($"[CLIENT][UDP] Received snapshot tick={snap.Tick}, entities={snap.Entities.Count}");
+                    GD.Print($"[CLIENT][UDP] Received snapshot tick={snap.Tick}, entities={snap.Entities.Count}");
 				}
 			}
 		}

--- a/Game/Utilities/Multiplayer/NetworkManager.cs
+++ b/Game/Utilities/Multiplayer/NetworkManager.cs
@@ -32,7 +32,7 @@ namespace Game.Utilities.Multiplayer
 		private Queue<Command> _incomingCommands = new();
 		private ulong _tick = 0;
 		private double _acc = 0;
-		private const float TICK_DELTA = 1f / 30f;
+		private const float TICK_DELTA = 1f / 60f;
 		private Timer shutdownTimer; // for headless server if no one is connected
 		private const float ServerShutdownDelay = 5f; // seconds 
 		public static NetworkManager Instance { get; set; }
@@ -48,7 +48,7 @@ namespace Game.Utilities.Multiplayer
 
 		public override void _Ready()
 		{
-			enableDebug = true; // Debugging aktivieren
+			enableDebug = false;
 			Engine.MaxFps = 60; // this is here because NetworkManager is an autoload (and it wont work in SettingsMenu for whatever reason). This means the whole game will be on 60 fps. Workaround but works
 			Instance = this;
 			// check if we are in headless server mode
@@ -351,7 +351,9 @@ namespace Game.Utilities.Multiplayer
 				var snap = Serializer.Deserialize<Snapshot>(data);
 				client.ApplySnapshot(snap);
 				DebugIt($"Received snapshot tick={snap.Tick}, entities={snap.Entities.Count}");
-				GD.Print($"[CLIENT][UDP] Received snapshot tick={snap.Tick}, entities={snap.Entities.Count}");
+				if (enableDebug) {
+					GD.Print($"[CLIENT][UDP] Received snapshot tick={snap.Tick}, entities={snap.Entities.Count}");
+				}
 			}
 		}
 
@@ -363,12 +365,18 @@ namespace Game.Utilities.Multiplayer
 				_acc -= TICK_DELTA;
 				if (_isServer)
 				{
-					GD.Print($"[SERVER][TICK] Tick={_tick}, Commands={_incomingCommands.Count}");
+					if (enableDebug)
+					{
+						GD.Print($"[SERVER][TICK] Tick={_tick}, Commands={_incomingCommands.Count}");
+					}
 					ProcessServerTick();
 				}
 				else
 				{
-					GD.Print($"[CLIENT][TICK] Tick={_tick}");
+					if (enableDebug)
+					{
+						GD.Print($"[CLIENT][TICK] Tick={_tick}");
+					}
 					SendClientCommand();
 				}
 				_tick++;


### PR DESCRIPTION
This pull request reduces the network tick rate (TICK_DELTA) from 1/60 to 1/30. The change aims to slow down the update frequency in order to prevent crashes and improve stability, especially on mobile clients.

During local multiplayer sessions (PC and mobile), the previous tick rate of 60 per second caused performance issues and frequent crashes on weaker devices. Lowering the tick rate to 30 per second reduces CPU and network load, resulting in smoother gameplay and fewer disconnects or crashes.

It needs to be tested on IOS