### PR TITLE
328 adjust wave difficulty

### DIFF
--- a/Game/Entities/Enemies/Goblin/default_enemy.tscn
+++ b/Game/Entities/Enemies/Goblin/default_enemy.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" uid="uid://ckw0iqrsdcp5k" path="res://Entities/Enemies/Goblin/BasicEnemy.cs" id="1_fecjr"]
 [ext_resource type="Script" uid="uid://c4qt4myebmju3" path="res://Entities/Shared/Health.cs" id="2_ihcfn"]
-[ext_resource type="Texture2D" uid="uid://bj5lkvqhdxwm8" path="res://Entities/Enemies/Goblin/Resources/Goblin_spritesheet.png" id="3_ihcfn"]
+[ext_resource type="Texture2D" uid="uid://dqfsl6qopn6pk" path="res://Entities/Enemies/Goblin/Resources/Goblin_spritesheet.png" id="3_ihcfn"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_r4aor"]
 radius = 26.0192
@@ -171,6 +171,8 @@ script = ExtResource("2_ihcfn")
 max_health = 100.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(-4, 10)
+scale = Vector2(0.7, 0.7)
 shape = SubResource("CircleShape2D_r4aor")
 
 [node name="AttackRange" type="Area2D" parent="."]

--- a/Game/Entities/Enemies/Rider/MountedEnemy.cs
+++ b/Game/Entities/Enemies/Rider/MountedEnemy.cs
@@ -89,7 +89,7 @@ public partial class MountedEnemy : EnemyBase
 			return;
 		}
 
-		var riderInstance = riderScene.Instantiate<CharacterBody2D>();
+		var riderInstance = riderScene.Instantiate<EnemyBase>();
 		if (riderInstance == null)
 		{
 			GD.PrintErr("Failed to instantiate Rider!");

--- a/Game/Entities/Enemies/Rider/mounted_enemy.tscn
+++ b/Game/Entities/Enemies/Rider/mounted_enemy.tscn
@@ -1,12 +1,12 @@
 [gd_scene load_steps=127 format=3 uid="uid://55ua147f3qds"]
 
 [ext_resource type="Script" uid="uid://4v08bsts05xi" path="res://Entities/Enemies/Rider/MountedEnemy.cs" id="1_script"]
-[ext_resource type="Texture2D" uid="uid://djvbruubd4goj" path="res://Entities/Enemies/Rider/Resources/MountedEnemyAttack.png" id="3_4ieiv"]
+[ext_resource type="Texture2D" uid="uid://b4fcprmyxcw5u" path="res://Entities/Enemies/Rider/Resources/MountedEnemyAttack.png" id="3_4ieiv"]
 [ext_resource type="Script" uid="uid://c4qt4myebmju3" path="res://Entities/Shared/Health.cs" id="3_health"]
-[ext_resource type="Texture2D" uid="uid://ckkfa077dj821" path="res://Entities/Enemies/Rider/Resources/MountedEnemyDeath.png" id="4_2ai7e"]
-[ext_resource type="Texture2D" uid="uid://by6wm834cpjfu" path="res://Entities/Enemies/Rider/Resources/MountedEnemyHit.png" id="5_4ieiv"]
-[ext_resource type="Texture2D" uid="uid://dmftdqeocigcy" path="res://Entities/Enemies/Rider/Resources/MountedEnemySprite.png" id="6_6sy85"]
-[ext_resource type="Texture2D" uid="uid://drk12616b3trc" path="res://Entities/Enemies/Rider/Resources/MountedEnemyWalk.png" id="7_x1df5"]
+[ext_resource type="Texture2D" uid="uid://clb868mev3hfe" path="res://Entities/Enemies/Rider/Resources/MountedEnemyDeath.png" id="4_2ai7e"]
+[ext_resource type="Texture2D" uid="uid://bmbpu2qyr8xo5" path="res://Entities/Enemies/Rider/Resources/MountedEnemyHit.png" id="5_4ieiv"]
+[ext_resource type="Texture2D" uid="uid://dwofyrpkq01ra" path="res://Entities/Enemies/Rider/Resources/MountedEnemySprite.png" id="6_6sy85"]
+[ext_resource type="Texture2D" uid="uid://b80bol6orqxr1" path="res://Entities/Enemies/Rider/Resources/MountedEnemyWalk.png" id="7_x1df5"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_body"]
 radius = 18.0
@@ -861,6 +861,7 @@ script = ExtResource("3_health")
 max_health = 100.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(4, -9)
 shape = SubResource("CircleShape2D_body")
 
 [node name="AttackRange" type="Area2D" parent="."]

--- a/Game/Entities/Enemies/Rider/rider_enemy.tscn
+++ b/Game/Entities/Enemies/Rider/rider_enemy.tscn
@@ -2,11 +2,11 @@
 
 [ext_resource type="Script" uid="uid://cwl1w7n2se2wd" path="res://Entities/Enemies/Rider/Rider.cs" id="1_k7dvb"]
 [ext_resource type="Script" uid="uid://c4qt4myebmju3" path="res://Entities/Shared/Health.cs" id="2_ilr60"]
-[ext_resource type="Texture2D" uid="uid://bgnsha0jt2pb7" path="res://Entities/Enemies/Rider/Resources/RiderAttack.png" id="3_eq5rk"]
-[ext_resource type="Texture2D" uid="uid://cn87a5tejrtb4" path="res://Entities/Enemies/Rider/Resources/RiderDeath.png" id="4_mlik0"]
-[ext_resource type="Texture2D" uid="uid://ntd5y6i0j5ee" path="res://Entities/Enemies/Rider/Resources/RiderHit.png" id="5_sg4oh"]
-[ext_resource type="Texture2D" uid="uid://cvp5u08yyimxc" path="res://Entities/Enemies/Rider/Resources/RiderIdle.png" id="6_xreqn"]
-[ext_resource type="Texture2D" uid="uid://vk2s337biy8k" path="res://Entities/Enemies/Rider/Resources/RiderWalk.png" id="7_pxerp"]
+[ext_resource type="Texture2D" uid="uid://36vpo3c3igsq" path="res://Entities/Enemies/Rider/Resources/RiderAttack.png" id="3_eq5rk"]
+[ext_resource type="Texture2D" uid="uid://bymsrreahsgv" path="res://Entities/Enemies/Rider/Resources/RiderDeath.png" id="4_mlik0"]
+[ext_resource type="Texture2D" uid="uid://comfn0pwhh020" path="res://Entities/Enemies/Rider/Resources/RiderHit.png" id="5_sg4oh"]
+[ext_resource type="Texture2D" uid="uid://c2aclhkwjrd30" path="res://Entities/Enemies/Rider/Resources/RiderIdle.png" id="6_xreqn"]
+[ext_resource type="Texture2D" uid="uid://bweeh7ji26e46" path="res://Entities/Enemies/Rider/Resources/RiderWalk.png" id="7_pxerp"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_2xkst"]
 radius = 15.0
@@ -1323,6 +1323,7 @@ script = ExtResource("2_ilr60")
 max_health = 100.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(0, 1)
 shape = SubResource("CircleShape2D_2xkst")
 
 [node name="AttackRange" type="Area2D" parent="."]

--- a/Game/Entities/Enemies/Skeleton/EnemyProjectile.cs
+++ b/Game/Entities/Enemies/Skeleton/EnemyProjectile.cs
@@ -22,10 +22,11 @@ public partial class EnemyProjectile : Area2D
 	private Vector2 direction;
 	private float lifetimeTimer = 0.0f;
 
-	public void Initialize(Vector2 dir, float damage)
+	public void Initialize(Vector2 dir, float damage, float speed)
 	{
 		direction = dir.Normalized();
 		Damage = damage;
+		Speed = speed;
 
 		// Set rotation based on direction
 		Rotation = direction.Angle();

--- a/Game/Entities/Enemies/Skeleton/RangedEnemy.cs
+++ b/Game/Entities/Enemies/Skeleton/RangedEnemy.cs
@@ -44,7 +44,7 @@ public partial class RangedEnemy : EnemyBase
 			GetParent().AddChild(projectile);
 
 			projectile.GlobalPosition = GlobalPosition;
-			projectile.Initialize(player.GlobalPosition - GlobalPosition, damage);
+			projectile.Initialize(player.GlobalPosition - GlobalPosition, damage, speed+(speed/5f));
 
 			if (enableDebug)
 			{

--- a/Game/Entities/Enemies/Skeleton/ranged_enemy.tscn
+++ b/Game/Entities/Enemies/Skeleton/ranged_enemy.tscn
@@ -3,7 +3,7 @@
 [ext_resource type="Script" uid="uid://c0iidoyspb4ve" path="res://Entities/Enemies/Skeleton/RangedEnemy.cs" id="1_1deiu"]
 [ext_resource type="PackedScene" uid="uid://brpwgptxilodd" path="res://Entities/Enemies/Skeleton/stone.tscn" id="2_e5mcm"]
 [ext_resource type="Script" uid="uid://c4qt4myebmju3" path="res://Entities/Shared/Health.cs" id="2_u2wu2"]
-[ext_resource type="Texture2D" uid="uid://bp8yxnu1qgli1" path="res://Entities/Enemies/Skeleton/Resources/skeleton_Spreadsheet.png" id="3_u2wu2"]
+[ext_resource type="Texture2D" uid="uid://b6xv62gu017nr" path="res://Entities/Enemies/Skeleton/Resources/skeleton_Spreadsheet.png" id="3_u2wu2"]
 
 [sub_resource type="CapsuleShape2D" id="CapsuleShape2D_u2wu2"]
 radius = 18.0
@@ -223,7 +223,8 @@ script = ExtResource("2_u2wu2")
 max_health = 100.0
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-position = Vector2(-2, 1)
+position = Vector2(-5, 14)
+scale = Vector2(0.7, 0.7)
 shape = SubResource("CapsuleShape2D_u2wu2")
 
 [node name="AttackRange" type="Area2D" parent="."]

--- a/Game/Utilities/Gameflow/Spawn/Patterns/ranged_enemy_big_triangle.tscn
+++ b/Game/Utilities/Gameflow/Spawn/Patterns/ranged_enemy_big_triangle.tscn
@@ -16,8 +16,7 @@ position = Vector2(50, 41)
 position = Vector2(-48, 40)
 
 [node name="RangedEnemy3" parent="." instance=ExtResource("2_lp3s2")]
-scale = Vector2(3, 3)
-speed = 120.0
+scale = Vector2(1.8, 1.8)
 
 [node name="RangedEnemy4" parent="." instance=ExtResource("2_lp3s2")]
 position = Vector2(-1, -63)

--- a/Game/Utilities/Gameflow/Spawn/SpawnEnemies.cs
+++ b/Game/Utilities/Gameflow/Spawn/SpawnEnemies.cs
@@ -177,7 +177,7 @@ public partial class SpawnEnemies : Node2D
 	}
 	private void OnWaveStart() 
 	{
-		if (_currentWave == 2) // the giant will spawn in wave 2 (Note: the normal enemies also spawn)
+		if (_currentWave % 5 == 2) // the giant will spawn in wave 2 (Note: the normal enemies also spawn)
 		{
 			spawnGiantBoss();
 		}

--- a/Game/Utilities/Gameflow/Spawn/SpawnEnemies.cs
+++ b/Game/Utilities/Gameflow/Spawn/SpawnEnemies.cs
@@ -177,6 +177,11 @@ public partial class SpawnEnemies : Node2D
 	}
 	private void OnWaveStart() 
 	{
+		_healthMultiplier = 1f + (_currentWave - 1) * 0.1f;
+		_damageMultiplier = 1f + (_currentWave - 1) * 0.5f;
+		_attackSpeedMultiplier = Math.Min(1f + (_currentWave - 1) * 0.05f , 2f);
+		_moveSpeedMultiplier = Math.Min(1f + (_currentWave - 1) * 0.05f , 2f);
+
 		if (_currentWave % 5 == 2) // the giant will spawn in wave 2 (Note: the normal enemies also spawn)
 		{
 			spawnGiantBoss();


### PR DESCRIPTION
Added enemy stat scaling
Adjusted enemy collision areas
Made skeleton projectile speed scale along with skeleton speed
Scaling values (all additive) per wave after the first:
> - health 10%
> - damage 50%
> - attackSpeed 5% with a cap of 200%
> - movementSpeed 5% with a cap of 200$

The attack and movement speed increases would reach their maximum at wave 41
Boss now spawns every 5th wave starting from 2nd