### PR TITLE
new orientation settings sensor_landscape

### DIFF
--- a/Game/project.godot
+++ b/Game/project.godot
@@ -30,6 +30,7 @@ SoundManager="*res://Audio/Manager/sound_manager.tscn"
 
 window/stretch/mode="viewport"
 window/stretch/aspect="expand"
+window/handheld/orientation=4
 window/force_fps=60
 window/vsync/use_vsync=true
 


### PR DESCRIPTION
Allows the game to rotate automatically when the device orientation changes by setting the screen orientation to sensor